### PR TITLE
Skirts and Tassets Coverage

### DIFF
--- a/modular_helmsguard/code/modules/clothing/pants.dm
+++ b/modular_helmsguard/code/modules/clothing/pants.dm
@@ -356,22 +356,20 @@
 	. = ..()
 	AddComponent(/datum/component/item_equipped_movement_rustle, SFX_PLATE_STEP)
 
+*/
+
 /obj/item/clothing/under/roguetown/chainlegs/skirt
-	name = "steel chain skirt"
-	desc = "A knee-length maille skirt, warding cuts against the thighs without slowing the feet."
+	name = "steel mail skirt"
+	desc = "A knee-length mail skirt, warding cuts against the thighs without slowing the feet."
 	icon_state = "chain_skirt"
 	item_state = "chain_skirt"
-	body_parts_covered = GROIN
-	armor_class = ARMOR_CLASS_LIGHT
+	body_parts_covered = LEGS
+	armor_class = ARMOR_CLASS_LIGHT	// Coverage to class trade.
 
 /obj/item/clothing/under/roguetown/platelegs/skirt
-	name = "steel plate tassets"
-	desc = "A set of hanging plates of steel to protect the hips and thighs without too much burden."
-	gender = PLURAL
-	icon_state = "plate_skirt"
-	item_state = "plate_skirt"
-	body_parts_covered = GROIN
-	armor_class = ARMOR_CLASS_LIGHT
+	body_parts_covered = LEGS
+	armor_class = ARMOR_CLASS_MEDIUM // Coverage to class trade.
+/*
 
 /obj/item/clothing/under/roguetown/loincloth
 	name = "loincloth"


### PR DESCRIPTION
Coverage of the mail skirt and tassets changed to legs from groin. Armor class of tassets increased from light to medium.

Mail skirt and tassets now have a use case; lighter armor class, higher protection, less coverage.

Merged into the rename branch to avoid duplication of effort.
